### PR TITLE
Allow indentation inside conditions

### DIFF
--- a/tslint.dist.yml
+++ b/tslint.dist.yml
@@ -3,6 +3,7 @@ sniffs:
     parameters:
       useSpaces: true
       indentPerLevel: 4
+      indentConditions: false
   - class: DeadCode
   - class: OperatorWhitespace
   - class: RepeatingRValue

--- a/tslint.yml
+++ b/tslint.yml
@@ -3,3 +3,4 @@ sniffs:
     parameters:
       useSpaces: false
       indentPerLevel: 1
+      indentConditions: false


### PR DESCRIPTION
* It's configurable, and default is as before, not indented
* Allow users to configure indentation of conditions, so it's possible
  to check whether TypoScript inside Conditions is intended