### PR TITLE
Only check for WS after operator when RValue exists

### DIFF
--- a/src/Helmich/TypoScriptLint/Linter/Sniff/OperatorWhitespaceSniff.php
+++ b/src/Helmich/TypoScriptLint/Linter/Sniff/OperatorWhitespaceSniff.php
@@ -58,7 +58,7 @@ class OperatorWhitespaceSniff implements TokenStreamSniffInterface
                 // Scan forward until we find the actual operator
                 for ($j = 0; $j < $count && !self::isOperator($tokensInLine[$j]); $j ++);
 
-                if (isset($tokensInLine[$j + 1]) && self::isBinaryOperator($tokensInLine[$j])) {
+                if (isset($tokensInLine[$j + 1]) && isset($tokensInLine[$j + 2]) && self::isBinaryOperator($tokensInLine[$j])) {
                     if (!self::isWhitespace($tokensInLine[$j + 1])) {
                         $file->addWarning(new Warning(
                             $tokensInLine[$j]->getLine(),

--- a/tests/functional/Helmich/TypoScriptLint/Tests/Linter/Fixtures/OperatorWhitespace/input.typoscript
+++ b/tests/functional/Helmich/TypoScriptLint/Tests/Linter/Fixtures/OperatorWhitespace/input.typoscript
@@ -5,3 +5,5 @@ d =  3
 e=4
 f< a
 g <a
+h =
+j = foo


### PR DESCRIPTION
Fixes #20