### PR TITLE
[FEATURE] Add "paths" config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,16 @@ If such a file is found, it will be merged with the `tslint.dist.yml` from the
 installation root directory. Have a look at [said file](tslint.dist.yml) for an
 idea of what you can configure (granted, not much yet).
 
+The paths to lint can be set via `tslint.yml`:
+
+```yaml
+paths:
+    - directory/with/typoscript
+    - ...
+```
+
 Since a local configuration file will be merged with the distributed
-configuration file, you *cannot* disable sniffs by simply removing them from the
-local configuration file (see this [bug report][issue-deadcode]
+configuration file, you *cannot* disable sniffs by simply removing them from the local configuration file (see this [bug report][issue-deadcode]
 for more information). To disable a sniff, use the `disabled` configuration
 property. For example, to disable the `DeadCode` sniff:
 

--- a/src/Helmich/TypoScriptLint/Command/LintCommand.php
+++ b/src/Helmich/TypoScriptLint/Command/LintCommand.php
@@ -111,7 +111,7 @@ class LintCommand extends Command
                 InputOption::VALUE_NONE,
                 'Set this flag to exit with a non-zero exit code when there are warnings.'
             )
-            ->addArgument('filename', InputArgument::REQUIRED | InputArgument::IS_ARRAY, 'File or directory names');
+            ->addArgument('paths', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'File or directory names');
     }
 
     /**
@@ -125,7 +125,8 @@ class LintCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $filenames        = $input->getArgument('filename');
+        $configuration    = $this->linterConfigurationLocator->loadConfiguration($input->getOption('config'));
+        $paths            = $input->getArgument('paths') ?: $configuration->getPaths();
         $outputTarget     = $input->getOption('output');
         $exitWithExitCode = $input->getOption('exit-code');
 
@@ -137,11 +138,10 @@ class LintCommand extends Command
             ? $output
             : new StreamOutput(fopen($input->getOption('output'), 'w'));
 
-        $configuration = $this->linterConfigurationLocator->loadConfiguration($input->getOption('config'));
         $printer       = $this->printerLocator->createPrinter($input->getOption('format'), $reportOutput);
         $report        = new Report();
 
-        foreach ($this->finder->getFilenames($filenames) as $filename) {
+        foreach ($this->finder->getFilenames($paths) as $filename) {
             $output->writeln("Linting input file <comment>{$filename}</comment>.");
             $this->linter->lintFile($filename, $report, $configuration, $output);
         }

--- a/src/Helmich/TypoScriptLint/Linter/LinterConfiguration.php
+++ b/src/Helmich/TypoScriptLint/Linter/LinterConfiguration.php
@@ -14,6 +14,22 @@ class LinterConfiguration implements ConfigurationInterface
         $this->configuration = $configuration;
     }
 
+    /**
+     * Get the list of paths to lint
+     *
+     * @return string[]
+     */
+    public function getPaths()
+    {
+        $paths = [];
+
+        if (!empty($this->configuration['paths'])) {
+            $paths = $this->configuration['paths'];
+        }
+
+        return $paths;
+    }
+
     public function getSniffConfigurations()
     {
         $sniffs = [];
@@ -43,17 +59,19 @@ class LinterConfiguration implements ConfigurationInterface
         $root = $treeBuilder->root('tslint');
         $root
             ->children()
-            ->arrayNode('sniffs')
-            ->isRequired()
-            ->useAttributeAsKey('class')
-            ->prototype('array')
-            ->children()
-            ->scalarNode('class')->end()
-            ->variableNode('parameters')->end()
-            ->booleanNode('disabled')->defaultValue(false)->end()
-            ->end()
-            ->end()
-            ->end()
+                ->arrayNode('paths')
+                    ->prototype('scalar')->end()
+                ->end()
+                ->arrayNode('sniffs')
+                    ->isRequired()
+                    ->useAttributeAsKey('class')
+                    ->prototype('array')
+                    ->children()
+                        ->scalarNode('class')->end()
+                        ->variableNode('parameters')->end()
+                        ->booleanNode('disabled')->defaultValue(false)->end()
+                    ->end()
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/tests/unit/Helmich/TypoScriptLint/Command/LintCommandTest.php
+++ b/tests/unit/Helmich/TypoScriptLint/Command/LintCommandTest.php
@@ -69,7 +69,7 @@ class LintCommandTest extends \PHPUnit_Framework_TestCase
                 ['config', 'config.yml']
             ]
         );
-        $in->expects($this->once())->method('getArgument')->with('filename')->willReturn(['foo.ts']);
+        $in->expects($this->once())->method('getArgument')->with('paths')->willReturn(['foo.ts']);
 
         $out = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
 
@@ -79,7 +79,7 @@ class LintCommandTest extends \PHPUnit_Framework_TestCase
     public function testCommandCallsLinterWithCorrectDependencies()
     {
         $in = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-        $in->expects($this->any())->method('getArgument')->with('filename')->willReturn(['foo.ts']);
+        $in->expects($this->any())->method('getArgument')->with('paths')->willReturn(['foo.ts']);
         $in->expects($this->any())->method('getOption')->willReturnMap(
             [
                 ['output', '-'],


### PR DESCRIPTION
This allows for setting the paths to lint through tslint.yml. Paths
passed via command line arguments take precedence over tslint.yml.

Fixes #18