### PR TITLE
Trigger "DeadCode" sniff only when comment contains parseable code

### DIFF
--- a/src/Linter/Sniff/DeadCodeSniff.php
+++ b/src/Linter/Sniff/DeadCodeSniff.php
@@ -24,7 +24,7 @@ class DeadCodeSniff implements TokenStreamSniffInterface
      * @param TokenInterface[]    $tokens
      * @param File                $file
      * @param LinterConfiguration $configuration
-     * @return mixed
+     * @return void
      */
     public function sniff(array $tokens, File $file, LinterConfiguration $configuration)
     {
@@ -50,7 +50,7 @@ class DeadCodeSniff implements TokenStreamSniffInterface
                         Issue::SEVERITY_INFO,
                         __CLASS__
                     ));
-                } catch (\Throwable $e) {
+                } catch (\Exception $e) {
                     // pass
                 }
             }

--- a/src/Linter/Sniff/DeadCodeSniff.php
+++ b/src/Linter/Sniff/DeadCodeSniff.php
@@ -4,6 +4,7 @@ namespace Helmich\TypoScriptLint\Linter\Sniff;
 use Helmich\TypoScriptLint\Linter\LinterConfiguration;
 use Helmich\TypoScriptLint\Linter\Report\File;
 use Helmich\TypoScriptLint\Linter\Report\Issue;
+use Helmich\TypoScriptParser\Parser\Parser;
 use Helmich\TypoScriptParser\Tokenizer\TokenInterface;
 use Helmich\TypoScriptParser\Tokenizer\Tokenizer;
 
@@ -38,13 +39,20 @@ class DeadCodeSniff implements TokenStreamSniffInterface
             if (preg_match(static::ANNOTATION_COMMENT, $commentContent)) {
                 continue;
             } else if (preg_match(Tokenizer::TOKEN_OPERATOR_LINE, $commentContent, $matches)) {
-                $file->addIssue(new Issue(
-                    $token->getLine(),
-                    0,
-                    'Found commented code (' . $matches[0] . ').',
-                    Issue::SEVERITY_INFO,
-                    __CLASS__
-                ));
+                try {
+                    $parser = new Parser(new Tokenizer());
+                    $parser->parseString($commentContent);
+
+                    $file->addIssue(new Issue(
+                        $token->getLine(),
+                        0,
+                        'Found commented code (' . $matches[0] . ').',
+                        Issue::SEVERITY_INFO,
+                        __CLASS__
+                    ));
+                } catch (\Throwable $e) {
+                    // pass
+                }
             }
         }
     }

--- a/tests/functional/Helmich/TypoScriptLint/Tests/Linter/Fixtures/DeadCodeFalsePositives/input.typoscript
+++ b/tests/functional/Helmich/TypoScriptLint/Tests/Linter/Fixtures/DeadCodeFalsePositives/input.typoscript
@@ -1,0 +1,4 @@
+# Reported in https://github.com/martin-helmich/typo3-typoscript-lint/issues/40
+
+# Processing <ol>, <ul> and <table> blocks separately
+foo = bar


### PR DESCRIPTION
Fixes #40