### PR TITLE
BUGFIX: Allow yaml file extension for configuration

### DIFF
--- a/src/Linter/Configuration/YamlConfigurationLoader.php
+++ b/src/Linter/Configuration/YamlConfigurationLoader.php
@@ -69,9 +69,7 @@ class YamlConfigurationLoader extends FileLoader
      */
     public function supports($resource, $type = null)
     {
-        return is_string($resource) && 'yml' === pathinfo(
-            $resource,
-            PATHINFO_EXTENSION
-        );
+        return is_string($resource) &&
+            in_array(pathinfo($resource, PATHINFO_EXTENSION), ['yml', 'yaml']);
     }
 }

--- a/tests/unit/Helmich/TypoScriptLint/Linter/Configuration/YamlConfigurationLoaderTest.php
+++ b/tests/unit/Helmich/TypoScriptLint/Linter/Configuration/YamlConfigurationLoaderTest.php
@@ -54,9 +54,14 @@ class YamlConfigurationLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals([], $this->loader->load('foobar.yml'));
     }
 
-    public function testSupportReturnsTrueForYamlFilenames()
+    public function testSupportReturnsTrueForYamlFilenamesWithYmlExtension()
     {
         $this->assertTrue($this->loader->supports('foobar.yml'));
+    }
+
+    public function testSupportReturnsTrueForYamlFilenamesWithYamlExtension()
+    {
+        $this->assertTrue($this->loader->supports('foobar.yaml'));
     }
 
     public function testSupportReturnsFalseForNoneYamlFilenames()


### PR DESCRIPTION
Allows to use yaml file extension, in addition to yml file extension,
for -c option on cli.

Resolves: #52