### PR TITLE
Add gcc style output formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ By default, it will print a report on the console. To generate a checkstyle-form
 
     vendor/bin/typoscript-lint -f xml -o checkstyle.xml path/to/your.typoscript
 
+To generate a report formatted according to the GNU Coding Standards, call as follows:
+
+    vendor/bin/typoscript-lint -f gcc path/to/your.typoscript
+
 ### Example
 
 [![asciicast](https://asciinema.org/a/1jOJv3Z6onWSdIkTAxAWsGgoy.png)](https://asciinema.org/a/1jOJv3Z6onWSdIkTAxAWsGgoy)

--- a/src/Linter/ReportPrinter/GccReportPrinter.php
+++ b/src/Linter/ReportPrinter/GccReportPrinter.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+namespace Helmich\TypoScriptLint\Linter\ReportPrinter;
+
+use Helmich\TypoScriptLint\Linter\Report\Report;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Report printer that generates an error report according to the GNU Coding Standards [1].
+ *
+ * [1] https://www.gnu.org/prep/standards/html_node/Errors.html
+ *
+ * @author     Stefan Szymanski <stefan.szymanski@posteo.de>
+ * @license    MIT
+ * @package    Helmich\TypoScriptLint
+ * @subpackage Linter\ReportPrinter
+ */
+class GccReportPrinter implements Printer
+{
+
+    /** @var OutputInterface */
+    private $output;
+
+    /**
+     * Constructs a new GCC report printer.
+     *
+     * @param OutputInterface $output Output stream to write on. Might be STDOUT or a file.
+     */
+    public function __construct(OutputInterface $output)
+    {
+        $this->output = $output;
+    }
+
+    /**
+     * Writes a report in GCC format.
+     *
+     * @param Report $report The report to print.
+     * @return void
+     */
+    public function writeReport(Report $report): void
+    {
+        foreach ($report->getFiles() as $file) {
+            foreach ($file->getIssues() as $issue) {
+                $this->output->writeLn(sprintf(
+                    "%s:%d:%d: %s: %s",
+                    $file->getFilename(),
+                    $issue->getLine() ?: 0,
+                    $issue->getColumn() ?: 0,
+                    $issue->getSeverity(),
+                    $issue->getMessage()
+                ));
+            }
+        }
+    }
+}

--- a/src/Logging/LinterLoggerBuilder.php
+++ b/src/Logging/LinterLoggerBuilder.php
@@ -4,6 +4,7 @@ namespace Helmich\TypoScriptLint\Logging;
 
 use Helmich\TypoScriptLint\Linter\ReportPrinter\CheckstyleReportPrinter;
 use Helmich\TypoScriptLint\Linter\ReportPrinter\ConsoleReportPrinter;
+use Helmich\TypoScriptLint\Linter\ReportPrinter\GccReportPrinter;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -42,6 +43,8 @@ class LinterLoggerBuilder
                 return new VerboseConsoleLogger(new ConsoleReportPrinter($reportOutput), $consoleOutput);
             case 'compact':
                 return new CompactConsoleLogger(new ConsoleReportPrinter($reportOutput), $consoleOutput);
+            case 'gcc':
+                return new MinimalConsoleLogger(new GccReportPrinter($reportOutput), $errorOutput);
             default:
                 throw new \InvalidArgumentException('Invalid report printer "' . $outputFormat . '"!');
         }

--- a/src/Logging/MinimalConsoleLogger.php
+++ b/src/Logging/MinimalConsoleLogger.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+namespace Helmich\TypoScriptLint\Logging;
+
+
+use Helmich\TypoScriptLint\Linter\Report\File;
+use Helmich\TypoScriptLint\Linter\Report\Report;
+use Helmich\TypoScriptLint\Linter\ReportPrinter\Printer;
+use Symfony\Component\Console\Output\OutputInterface;
+
+
+/**
+ * Minimal console logger
+ *
+ * This logger prints only the issues to the console.
+ *
+ * @author     Stefan Szymanski <stefan.szymanski@posteo.de>
+ * @license    MIT
+ * @package    Helmich\TypoScriptLint
+ * @subpackage Logging
+ */
+class MinimalConsoleLogger implements LinterLoggerInterface
+{
+    /** @var Printer */
+    private $printer;
+
+    /** @var OutputInterface */
+    private $output;
+
+    public function __construct(Printer $printer, OutputInterface $output)
+    {
+        $this->printer = $printer;
+        $this->output = $output;
+    }
+
+    public function notifyFileNotFound(string $file): void
+    {
+        $this->output->writeln("<error>WARNING: Input file ${file} does not seem to exist.</error>");
+    }
+
+    public function notifyFiles(array $files): void
+    {
+    }
+
+    public function notifyFileStart(string $filename): void
+    {
+    }
+
+    public function notifyFileSniffStart(string $filename, string $sniffClass): void
+    {
+    }
+
+    public function nofifyFileSniffComplete(string $filename, string $sniffClass, File $report): void
+    {
+    }
+
+    public function notifyFileComplete(string $filename, File $report): void
+    {
+    }
+
+    public function notifyRunComplete(Report $report): void
+    {
+        $this->printer->writeReport($report);
+    }
+}

--- a/tests/unit/Helmich/TypoScriptLint/Linter/Logging/LinterLoggerBuilderTest.php
+++ b/tests/unit/Helmich/TypoScriptLint/Linter/Logging/LinterLoggerBuilderTest.php
@@ -3,6 +3,7 @@ namespace Helmich\TypoScriptLint\Tests\Unit\Logging;
 
 use Helmich\TypoScriptLint\Logging\CompactConsoleLogger;
 use Helmich\TypoScriptLint\Logging\LinterLoggerBuilder;
+use Helmich\TypoScriptLint\Logging\MinimalConsoleLogger;
 use Helmich\TypoScriptLint\Logging\VerboseConsoleLogger;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -37,6 +38,12 @@ class LinterLoggerBuilderTest extends TestCase
     {
         $logger = $this->builder->createLogger('xml', new BufferedOutput(), new BufferedOutput());
         assertThat($logger, self::isInstanceOf(CompactConsoleLogger::class));
+    }
+
+    public function testGccLoggerCanBeBuilt()
+    {
+        $logger = $this->builder->createLogger('gcc', new BufferedOutput(), new BufferedOutput());
+        assertThat($logger, self::isInstanceOf(MinimalConsoleLogger::class));
     }
 
     public function testUnknownFormatCausesInvalidArgumentException()

--- a/tests/unit/Helmich/TypoScriptLint/Linter/ReportPrinter/GccReportPrinterTest.php
+++ b/tests/unit/Helmich/TypoScriptLint/Linter/ReportPrinter/GccReportPrinterTest.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+namespace Helmich\TypoScriptLint\Tests\Unit\Linter\ReportPrinter;
+
+use Helmich\TypoScriptLint\Linter\Report\File;
+use Helmich\TypoScriptLint\Linter\Report\Report;
+use Helmich\TypoScriptLint\Linter\Report\Issue;
+use Helmich\TypoScriptLint\Linter\ReportPrinter\GccReportPrinter;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+/**
+ * @covers \Helmich\TypoScriptLint\Linter\ReportPrinter\GccReportPrinter
+ * @uses   \Helmich\TypoScriptLint\Linter\Report\File
+ * @uses   \Helmich\TypoScriptLint\Linter\Report\Report
+ * @uses   \Helmich\TypoScriptLint\Linter\Report\Issue
+ */
+class GccReportPrinterTest extends TestCase
+{
+
+    const EXPECTED_OUTPUT = 'foobar.tys:123:12: info: Message #1
+foobar.tys:124:0: warning: Message #2
+bar.txt:412:141: error: Message #3
+';
+
+    /** @var BufferedOutput */
+    private $output;
+
+    /** @var ConsoleReportPrinter */
+    private $printer;
+
+    public function setUp(): void
+    {
+        $this->output  = new BufferedOutput();
+        $this->printer = new GccReportPrinter($this->output);
+    }
+
+    /**
+     * @medium
+     */
+    public function testGccReportIsCorrectlyGenerated()
+    {
+        $file1 = new File('foobar.tys');
+        $file1->addIssue(new Issue(123, 12, 'Message #1', Issue::SEVERITY_INFO, 'foobar'));
+        $file1->addIssue(new Issue(124, 0, 'Message #2', Issue::SEVERITY_WARNING, 'foobar'));
+
+        $file2 = new File('bar.txt');
+        $file2->addIssue(new Issue(412, 141, 'Message #3', Issue::SEVERITY_ERROR, 'barbaz'));
+
+        $report = new Report();
+        $report->addFile($file1);
+        $report->addFile($file2);
+
+        $this->printer->writeReport($report);
+
+        $this->assertEquals(self::EXPECTED_OUTPUT, $this->output->fetch());
+    }
+}


### PR DESCRIPTION
I added the gcc style formatting to use `typoscript-lint` in neovim with coc-diagnostic.