### PR TITLE
Add sniff which check for config.no_cache=1 usages

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,12 @@ Raises warnings about empty assignment blocks:
     foo {
     }
 
+#### Discourage config.no_cache = 1
+
+Raises warning about usage of `config.no_cache = 1`.
+Instead USER_INT or COA_INT should be used.
+
+
 ### Configuration
 
 `typoscript-lint` looks for a file `typoscript-lint.yml` in the current working directory.

--- a/src/Linter/Sniff/ConfigNoCacheSniff.php
+++ b/src/Linter/Sniff/ConfigNoCacheSniff.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+namespace Helmich\TypoScriptLint\Linter\Sniff;
+
+use Helmich\TypoScriptLint\Linter\Sniff\Visitor\ConfigNoCacheVisitor;
+use Helmich\TypoScriptLint\Linter\Sniff\Visitor\SniffVisitor;
+
+class ConfigNoCacheSniff extends AbstractSyntaxTreeSniff {
+    /**
+     * @return SniffVisitor
+     */
+    protected function buildVisitor(): SniffVisitor
+    {
+        return new ConfigNoCacheVisitor();
+    }
+}

--- a/src/Linter/Sniff/Visitor/ConfigNoCacheVisitor.php
+++ b/src/Linter/Sniff/Visitor/ConfigNoCacheVisitor.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace Helmich\TypoScriptLint\Linter\Sniff\Visitor;
+
+use Helmich\TypoScriptLint\Linter\Report\Issue;
+use Helmich\TypoScriptLint\Linter\Sniff\ConfigNoCacheSniff;
+use Helmich\TypoScriptParser\Parser\AST\Operator\Assignment;
+use Helmich\TypoScriptParser\Parser\AST\Statement;
+
+class ConfigNoCacheVisitor implements SniffVisitor
+{
+    /** @var Issue[] */
+    private $issues = [];
+
+    /**
+     * @return Issue[]
+     */
+    public function getIssues(): array
+    {
+        return $this->issues;
+    }
+
+    public function enterTree(array $statements): void
+    {
+    }
+
+    public function enterNode(Statement $statement): void
+    {
+         if (!$statement instanceof Assignment) {
+             return;
+         }
+         if ($statement->object->relativeName !== 'no_cache'
+             && substr($statement->object->relativeName, -9) !== '.no_cache') {
+             return;
+         }
+         if ($statement->value->value !== '0') {
+             $this->issues[] = new Issue(
+                $statement->sourceLine,
+                null,
+                sprintf(
+                    'Setting config.no_cache = 1 is discouraged as it is bad for performance. '
+                        . 'Consider using USER_INT object instead. Found in path: %s',
+                    $statement->object->absoluteName
+                ),
+                Issue::SEVERITY_WARNING,
+                ConfigNoCacheSniff::class
+            );
+         }
+    }
+
+    public function exitNode(Statement $statement): void
+    {
+    }
+
+    public function exitTree(array $statements): void
+    {
+    }
+}

--- a/tests/functional/Helmich/TypoScriptLint/Tests/Linter/Fixtures/ConfigNoCache/input.typoscript
+++ b/tests/functional/Helmich/TypoScriptLint/Tests/Linter/Fixtures/ConfigNoCache/input.typoscript
@@ -1,0 +1,13 @@
+testPage2 = PAGE
+testPage2.config.no_cache = 1
+
+testPage = PAGE
+testPage {
+    typeNum = 22322
+    config {
+        no_cache = 1
+    }
+}
+
+testPage3 = PAGE
+testPage3.config.no_cache = 0

--- a/tests/functional/Helmich/TypoScriptLint/Tests/Linter/Fixtures/ConfigNoCache/output.txt
+++ b/tests/functional/Helmich/TypoScriptLint/Tests/Linter/Fixtures/ConfigNoCache/output.txt
@@ -1,0 +1,2 @@
+2;;Setting config.no_cache = 1 is discouraged as it is bad for performance. Consider using USER_INT object instead. Found in path: testPage2.config.no_cache;warning;Helmich\TypoScriptLint\Linter\Sniff\ConfigNoCacheSniff
+8;;Setting config.no_cache = 1 is discouraged as it is bad for performance. Consider using USER_INT object instead. Found in path: testPage.config.no_cache;warning;Helmich\TypoScriptLint\Linter\Sniff\ConfigNoCacheSniff

--- a/tests/functional/Helmich/TypoScriptLint/Tests/Linter/Fixtures/typoscript-lint.dist.yml
+++ b/tests/functional/Helmich/TypoScriptLint/Tests/Linter/Fixtures/typoscript-lint.dist.yml
@@ -13,3 +13,4 @@ sniffs:
   - class: DuplicateAssignment
   - class: NestingConsistency
   - class: EmptySection
+  - class: ConfigNoCache


### PR DESCRIPTION
Usage of the config.no_cache is discouraged as it result in performance penalty when multiple requests are coming in parallel
(high lock waits).
Instead USER_INT or COA_INT should be used.

solves: 
https://github.com/martin-helmich/typo3-typoscript-lint/issues/102