### PR TITLE
Ignore empty lines when checking indentation

### DIFF
--- a/src/Linter/Sniff/IndentationSniff.php
+++ b/src/Linter/Sniff/IndentationSniff.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Helmich\TypoScriptLint\Linter\Sniff;
 
 use Helmich\TypoScriptLint\Linter\LinterConfiguration;
@@ -72,7 +75,7 @@ class IndentationSniff implements TokenStreamSniffInterface
                 $expectedIndentationCharacterCount
             );
 
-            $tokensInLine = array_values(array_filter($tokensInLine, function(TokenInterface $token): bool {
+            $tokensInLine = array_values(array_filter($tokensInLine, function (TokenInterface $token): bool {
                 return $token->getType() !== TokenInterface::TYPE_RIGHTVALUE_MULTILINE;
             }));
 
@@ -105,6 +108,14 @@ class IndentationSniff implements TokenStreamSniffInterface
      */
     private function isEmptyLine(array $tokensInLine): bool
     {
+        $tokensInLine = array_values(array_filter($tokensInLine, function (TokenInterface $t): bool {
+            return $t->getType() !== TokenInterface::TYPE_EMPTY_LINE;
+        }));
+
+        if (count($tokensInLine) === 0) {
+            return true;
+        }
+
         if (count($tokensInLine) > 1) {
             return false;
         }

--- a/tests/functional/Helmich/TypoScriptLint/Tests/Linter/Fixtures/Indentation/input.typoscript
+++ b/tests/functional/Helmich/TypoScriptLint/Tests/Linter/Fixtures/Indentation/input.typoscript
@@ -1,4 +1,5 @@
 foo {
     bar = 2
+
   baz = 5
 }

--- a/tests/functional/Helmich/TypoScriptLint/Tests/Linter/Fixtures/Indentation/output.txt
+++ b/tests/functional/Helmich/TypoScriptLint/Tests/Linter/Fixtures/Indentation/output.txt
@@ -1,1 +1,1 @@
-3;2;Expected indent of 4 spaces.;warning;Helmich\TypoScriptLint\Linter\Sniff\IndentationSniff
+4;2;Expected indent of 4 spaces.;warning;Helmich\TypoScriptLint\Linter\Sniff\IndentationSniff


### PR DESCRIPTION
This fixes a regression caused by a change in a dependency (martin-helmich/typo3-typoscript-parser#61). That change made empty statements (read: empty lines) turn up in the token stream (which was on purpose, since it actually allows more insight into how the code was originally formatted before lexical analysis). Unfortunately, that messed up the IndentationSniff, which now also expected these empty lines to have indentation.

This change modifies the IndentationSniff to explicitly exclude empty lines from analysis.

Fixes #115 