### PR TITLE
Add box phar compilation, make compile command, and installation notes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,4 @@
 README.md:
 	doctoc README.md --github --notitle --maxlevel=3
+compile:
+	box compile

--- a/README.md
+++ b/README.md
@@ -70,6 +70,17 @@ In this case, it will be installed into the `./tools` folder of your current dir
 
     ./tools/typoscript-lint path/to/your.typoscript
 
+### Setup (using [box](https://github.com/box-project/box))
+
+You can build a stand-alone `typoscript-lint.phar` file using box:
+
+    box compile
+
+You can then make this available system wide:
+
+    sudo chmod a+x typoscript-lint.phar
+    sudo mv typoscript-lint.phar /usr/local/bin/typoscript-lint
+
 ### Usage
 
 Call typo3-typoscript-lint as follows:

--- a/box.json
+++ b/box.json
@@ -1,0 +1,17 @@
+{
+	"directories": [
+		"src",
+		"vendor"
+	],
+	"files": [
+		"psalm.xml",
+		"services.yml",
+		"typoscript-lint.yml",
+		"LICENSE"
+	],
+	"main": "typoscript-lint",
+	"output": "typoscript-lint.phar",
+	"compression": "GZ",
+	"chmod": "0775",
+	"stub": true
+}


### PR DESCRIPTION
I'm not sure what tools were intended to generate a Phar, but I added some support for [box](https://github.com/box-project/box).

The `box.json` allows us to `box compile`; `make compile` just calls that.

Also added some notes to `README.md` to cover installation to `/usr/local/bin`, based on the latter steps in [PHP-CS-Fixer - Global (Manual)](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/doc/installation.rst#globally-manual)