### PR TITLE
[BUGFIX] Block Dependabot updates for Symfony components

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,5 @@ updates:
     interval: daily
     time: "04:00"
   open-pull-requests-limit: 10
+  ignore:
+    - dependency-name: "symfony/*"


### PR DESCRIPTION
Dependabot does not recognize multi-version dependencies and will happily mangle them (like in #143).