### PR TITLE
[BUGFIX] Do not check the lockfile on `composer validate`

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -38,8 +38,8 @@ jobs:
         extensions: mbstring, intl, json
         coverage: pcov
 
-    - name: Validate composer.json and composer.lock
-      run: composer validate
+    - name: Validate composer.json
+      run: composer validate --no-check-lock
 
     - name: Declare required Symfony version
       run: |


### PR DESCRIPTION
As this package (rightfully) does not ship a `composer.lock`, there is not point validating that file during `composer validate`.