### PR TITLE
[TASK] Sync the `.editorconfig` with the TYPO3 coding standards package

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,32 +2,59 @@
 
 # top-most EditorConfig file
 root = true
-charset = utf-8
-
-# Get rid of whitespace to avoid diffs with a bunch of EOL changes
-trim_trailing_whitespace = true
 
 # Unix-style newlines with a newline ending every file
 [*]
+charset = utf-8
 end_of_line = lf
+indent_style = space
+indent_size = 4
 insert_final_newline = true
+trim_trailing_whitespace = true
+
+# TS/JS-Files
+[*.{ts,js}]
+indent_size = 2
 
 # JSON-Files
 [*.json]
 indent_style = tab
-indent_size = 4
 
-# PHP-Files
-[*.php]
-indent_style = space
+# ReST-Files
+[*.{rst,rst.txt}]
 indent_size = 4
+max_line_length = 80
 
-# MD-Files
+# Markdown-Files
 [*.md]
-indent_style = space
-indent_size = 4
+max_line_length = 80
+
+# YAML-Files
+[*.{yaml,yml}]
+indent_size = 2
+
+# NEON-Files
+[*.neon]
+indent_size = 2
+indent_style = tab
+
+# package.json
+[package.json]
+indent_size = 2
 
 # TypoScript
-[*.ts]
-indent_style = space
+[*.{typoscript,tsconfig}]
 indent_size = 2
+
+# XLF-Files
+[*.xlf]
+indent_style = tab
+
+# SQL-Files
+[*.sql]
+indent_style = tab
+indent_size = 2
+
+# .htaccess
+[{_.htaccess,.htaccess}]
+indent_style = tab


### PR DESCRIPTION
This allows to keep things consistent with other TYPO3-related packages, and also covers some more file types.