### PR TITLE
Print checkstyle report even if empty

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,9 @@
 		"symfony/filesystem": "^5.4 || ^6.4 || ^7.0",
 		"symfony/event-dispatcher": "^5.4 || ^6.4 || ^7.0",
 		"helmich/typo3-typoscript-parser": "^2.3",
-		"ext-json": "*"
-	},
+		"ext-json": "*",
+      	"ext-dom": "*"
+    },
 	"require-dev": {
 		"phpunit/phpunit": "^9.6.8",
 		"mikey179/vfsstream": "^1.6.11",

--- a/src/Linter/Report/Report.php
+++ b/src/Linter/Report/Report.php
@@ -52,6 +52,11 @@ class Report
         return $count;
     }
 
+    public function hasIssues(): bool
+    {
+        return $this->countIssues() > 0;
+    }
+
     /**
      * Returns the number of issues with a given severity for the entire report
      *

--- a/src/Linter/ReportPrinter/ConsoleReportPrinter.php
+++ b/src/Linter/ReportPrinter/ConsoleReportPrinter.php
@@ -40,6 +40,10 @@ class ConsoleReportPrinter implements Printer
      */
     public function writeReport(Report $report): void
     {
+        if (!$report->hasIssues()) {
+            return;
+        }
+
         $count = 0;
 
         $this->output->writeln('');

--- a/src/Linter/ReportPrinter/Printer.php
+++ b/src/Linter/ReportPrinter/Printer.php
@@ -13,5 +13,10 @@ use Helmich\TypoScriptLint\Linter\Report\Report;
 interface Printer
 {
 
+    /**
+     * @param Report $report
+     * @return void
+     * @throws PrinterException
+     */
     public function writeReport(Report $report): void;
 }

--- a/src/Linter/ReportPrinter/PrinterException.php
+++ b/src/Linter/ReportPrinter/PrinterException.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace Helmich\TypoScriptLint\Linter\ReportPrinter;
+
+use Exception;
+use Throwable;
+
+class PrinterException extends Exception
+{
+    public function __construct(string $message, ?Throwable $previous = null)
+    {
+        parent::__construct($message, 0, $previous);
+    }
+}

--- a/src/Logging/CompactConsoleLogger.php
+++ b/src/Logging/CompactConsoleLogger.php
@@ -103,10 +103,10 @@ class CompactConsoleLogger implements LinterLoggerInterface
 
         if ($this->issueCount > 0) {
             $this->output->writeln("Completed with <comment>{$this->issueCount} issues</comment>");
-
-            $this->printer->writeReport($report);
         } else {
             $this->output->writeln("Complete <info>without warnings</info>");
         }
+
+        $this->printer->writeReport($report);
     }
 }


### PR DESCRIPTION
Fixes #185

- Print report always, regardless of issue count
- Add (previously undeclared) ext-dom requirement to composer.json
- Refactor checkstyle report printer
